### PR TITLE
Remove override from command_data_configuration

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -89,7 +89,7 @@ public:
    * for the controlled joints
    */
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
-  std::vector<std::string> command_data_configuration() const override;
+  std::vector<std::string> command_data_configuration() const;
 
   JOINT_TRAJECTORY_CONTROLLER_PUBLIC
   controller_interface::return_type update(


### PR DESCRIPTION
I don't think that command_data_configuration overloads anything; caused a build error for me, but maybe I missed something?